### PR TITLE
sailfish: hammerhead: add soundless video.gep, as gst-libav is not redist

### DIFF
--- a/data/sailfish/hammerhead/video.gep
+++ b/data/sailfish/hammerhead/video.gep
@@ -1,0 +1,18 @@
+[GStreamer Encoding Target]
+name=video-profile
+category=device
+description=Video encoding profiles
+
+[profile-mpeg4-video]
+name=video-profile
+type=container
+description[c]=Standard MPEG-4 video profile
+format=video/quicktime, variant=(string)iso
+
+[streamprofile-mpeg4-video-0]
+parent=video-profile
+type=video
+format=video/mpeg, mpegversion=(int)4
+presence=1
+pass=0
+variableframerate=true

--- a/rpm/harbour-cameraplus.spec
+++ b/rpm/harbour-cameraplus.spec
@@ -62,9 +62,11 @@ cp %SOURCE2 $RPM_BUILD_ROOT/usr/share/icons/hicolor/86x86/apps/
 # qtcamera configuration
 mkdir -p $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/
 mkdir -p $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/jolla/
+mkdir -p $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/nexus\ 5/
 cp data/sailfish/qtcamera.ini $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/
 cp data/sailfish/jolla/resolutions.ini $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/jolla/
 cp data/sailfish/video.gep $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/
+cp data/sailfish/hammerhead/video.gep $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/nexus\ 5/
 cp data/sailfish/image.gep $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/
 cp data/sailfish/properties.ini $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/
 


### PR DESCRIPTION
This will show working viewfinder out-of-the-box on current Nexus 5 port; tested successfully.

It then showcases a working proof-of-concept to the community, and so to gain traction for more contributions (resolution and battery glitches are then the only two issues keeping users away from a working camera on N5).
