### PR TITLE
Contributing to configs

### DIFF
--- a/lib/qtcamconfig.cpp
+++ b/lib/qtcamconfig.cpp
@@ -118,9 +118,9 @@ QtCamConfig::QtCamConfig(QObject *parent) :
   d_ptr(new QtCamConfigPrivate) {
 
 #ifdef QT4
-  d_ptr->model = QtMobility::QSystemDeviceInfo().model().toLower();
+  d_ptr->model = QtMobility::QSystemDeviceInfo().productName().toLower();
 #else
-  d_ptr->model = QDeviceInfo().model().toLower();
+  d_ptr->model = QDeviceInfo().productName().toLower();
 #endif
 
   d_ptr->conf = new QSettings(lookUp("qtcamera.ini"), QSettings::IniFormat, this);

--- a/rpm/harbour-cameraplus.spec
+++ b/rpm/harbour-cameraplus.spec
@@ -69,14 +69,15 @@ cp %SOURCE2 $RPM_BUILD_ROOT/usr/share/icons/hicolor/86x86/apps/
 
 # qtcamera configuration
 mkdir -p $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/
-mkdir -p $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/jolla/
-mkdir -p $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/nexus\ 5/
+mkdir -p $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/jp-1301/
+mkdir -p $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/hammerhead/
 cp data/sailfish/qtcamera.ini $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/
-cp data/sailfish/jolla/resolutions.ini $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/jolla/
+cp data/sailfish/jolla/resolutions.ini $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/jp-1301/
 cp data/sailfish/video.gep $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/
-cp data/sailfish/hammerhead/video.gep $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/nexus\ 5/
+cp data/sailfish/hammerhead/video.gep $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/hammerhead/
 cp data/sailfish/image.gep $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/
 cp data/sailfish/properties.ini $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/
+cp data/sailfish/qtcamera.ini $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/
 
 # qtcamera tools
 cp tools/dump_resolutions $RPM_BUILD_ROOT/usr/bin/

--- a/rpm/harbour-cameraplus.spec
+++ b/rpm/harbour-cameraplus.spec
@@ -44,6 +44,14 @@ BuildRequires:  quill-qt5-utils
 %description
 Cameraplus is an advanced easy to use camera
 
+%package tools
+Summary: Tools for cameraplus
+Group: Applications/Multimedia
+Requires:  harbour-cameraplus = %{version}-%{release}
+
+%description tools
+%{summary}
+
 %prep
 %setup -q
 
@@ -69,6 +77,9 @@ cp data/sailfish/video.gep $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qt
 cp data/sailfish/hammerhead/video.gep $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/nexus\ 5/
 cp data/sailfish/image.gep $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/
 cp data/sailfish/properties.ini $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/qtcamera/config/
+
+# qtcamera tools
+cp tools/dump_resolutions $RPM_BUILD_ROOT/usr/bin/
 
 # cameraplus configuration
 mkdir -p $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/share/cameraplus/config/
@@ -134,3 +145,8 @@ cp /usr/lib/libquill-qt5.so.* $RPM_BUILD_ROOT/usr/share/harbour-cameraplus/lib/
 # dependencies
 %{_datadir}/harbour-cameraplus/share/*
 %{_datadir}/harbour-cameraplus/lib/*
+
+%files tools
+%defattr(-,root,root,-)
+%{_bindir}/dump_resolutions
+


### PR DESCRIPTION
Ship dump_resolutions so user can inquire all other resolutions, also resolutions on a not-yet-ported-to device;
put configs files under device's codename folder dir, which won't have spaces in its name
